### PR TITLE
Fixes a bug when using Instant - Duration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ impl std::ops::Sub for Instant {
 impl std::ops::Sub<Duration> for Instant {
     type Output = Instant;
     fn sub(self, rhs: Duration) -> Self::Output {
-        self.checked_add(rhs)
+        self.checked_sub(rhs)
             .expect("overflow when substracting duration from instant")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,12 @@ mod tests {
             Instant(Duration::from_millis(41))
         );
 
+        // now - 1 = diff - 1
+        assert_eq!(
+            Instant::now() - Duration::from_millis(1),
+            Instant(Duration::from_millis(41))
+        );
+
         // now - diff + 1 = none
         assert!(Instant::now()
             .checked_sub(Duration::from_millis(43))


### PR DESCRIPTION
When calling `Instant::now() - Duration::from_secs(1)` we expect the same result
as when calling `Instant::now().checked_sub(Duration::from_secs(1))`. However,
as Sub::sub for Instant calls checked_add instead we got a wrong result.

This patch will fix the bug.