### PR TITLE
[fixup d9afb747e7f10de0a62f1db5c1df71712b7e01de]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ mod reference {
         *TIME.get_or_init(Mutex::default).lock().unwrap()
     }
 
-    pub fn with_system_time(d: impl Fn(&mut Duration)) -> Duration {
+    pub fn with_system_time(d: impl Fn(&mut Duration)) {
         let t = SYSTEM_TIME.get_or_init(Mutex::default);
         let mut t = t.lock().unwrap();
         d(&mut t);


### PR DESCRIPTION
Thanks for `mock_instant`!

Hi, a commit from April broke the build when the `sync` feature is enabled.
I've fixed it (it looks fine but disclaimer: I have not read all the logic from this file to double-check before committing)