### PR TITLE
fix: cargo clippy warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,11 +96,11 @@ mod reference {
     }
 
     pub fn with_time(d: impl Fn(&mut Duration)) {
-        TIME.with(|t| d(&mut *t.borrow_mut()))
+        TIME.with(|t| d(&mut t.borrow_mut()))
     }
 
     pub fn with_system_time(d: impl Fn(&mut Duration)) {
-        SYSTEM_TIME.with(|t| d(&mut *t.borrow_mut()))
+        SYSTEM_TIME.with(|t| d(&mut t.borrow_mut()))
     }
 
     pub fn get_time() -> Duration {


### PR DESCRIPTION
`warning: deref which would be done by auto-deref`