### PR TITLE
Bringing `Instant::duration_since()` in line with std

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -68,7 +68,7 @@ macro_rules! define_instant {
             }
 
             pub fn duration_since(&self, earlier: Self) -> Duration {
-                self.0 - earlier.0
+                self.checked_duration_since(earlier).unwrap_or_default()
             }
 
             pub fn checked_duration_since(&self, earlier: Self) -> Option<Duration> {
@@ -406,12 +406,27 @@ macro_rules! define_instant_tests {
                     interval
                 );
 
-                // 0 since now = none
-                assert!(instant.checked_duration_since(Instant::now()).is_none());
+                // 0 since now = 0
+                assert_eq!(
+                    instant.saturating_duration_since(Instant::now()),
+                    Duration::ZERO
+                );
 
                 // now since 0 = diff
                 assert_eq!(
-                    Instant::now().checked_duration_since(instant).unwrap(),
+                    Instant::now().saturating_duration_since(instant),
+                    interval
+                );
+
+                // 0 since now = 0 - same behavior as saturating_duration_since
+                assert_eq!(
+                    instant.duration_since(Instant::now()),
+                    Duration::ZERO
+                );
+
+                // now since 0 = diff
+                assert_eq!(
+                    Instant::now().duration_since(instant),
                     interval
                 );
 


### PR DESCRIPTION
You can see that in `std::time:Instant` `duration_since()` behaves the same as `saturating_duration_since()`
https://github.com/rust-lang/rust/blob/master/library/std/src/time.rs#L313
This was not the case here. Also added tests for `duration_since()` and `saturating_duration_since()` and removed duplicated test for `checked_duration_since()`.